### PR TITLE
Add a github action for the deploy

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,15 @@
+workflow "Deploy to GitHub Pages" {
+  on = "push"
+  resolves = ["Build and push docs"]
+}
+
+action "Filter branch" {
+  uses = "actions/bin/filter@master"
+  args = "branch develop"
+}
+
+action "Build and push docs" {
+  needs = ["Filter branch"]
+  uses = "clay/docusaurus-github-action@master"
+  secrets = ["DEPLOY_SSH_KEY"]
+}


### PR DESCRIPTION
Add deploy process for the docs using the [docusaurus action repo](https://github.com/clay/docusaurus-github-action/)

# Steps for testing the site locally:
- Install [act](https://github.com/nektos/act#installation)
- Go to the [`.github` ](https://github.com/clay/clay.github.io/tree/73731c56a890a900ccc512d4ba4e773c9826779b/.github) folder
- On the `main.workflow` update the[`branch`](https://github.com/clay/clay/blob/action_deploy/.github/main.workflow?short_path=b3f443d#L8) line to use `branch action_deploy`
- Use the [`act`](https://github.com/nektos/act#commands) command to simulate a `push` event. The build should be `successful`
- On the `main.workflow` update the[` branch`](https://github.com/clay/clay.github.io/blob/73731c5/.github/main.workflow?short_path=b29ff03#L8) line to use `branch master`
- Use the [`act`](https://github.com/nektos/act#commands) command to simulate a `push` event.  The build should be `decline`