### PR TITLE
[BLOCKED]Add search config for the docs

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -15,5 +15,5 @@ action "Build and push docs" {
   env = {
     PROJECT_NAME = "clay"
   }
-  secrets = ["DEPLOY_SSH_KEY"]
+  secrets = ["DEPLOY_SSH_KEY", "ALGOLIA_API_KEY"]
 }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -95,7 +95,12 @@ const siteConfig = {
   // template. For example, if you need your repo's URL...
   //   repoUrl: 'https://github.com/facebook/test-site',
 
-  cname: 'docs.clayplatform.com'
+  cname: 'docs.clayplatform.com',
+  algolia: {
+    apiKey: process.env.ALGOLIA_API_KEY,
+    indexName: 'TBD',
+    algoliaOptions: {} // Optional, if provided by Algolia
+  }
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Add search config for the docs

# Steps for testing the site locally:
- Go to the `website` folder
- Install package using `npm install`
- Start your local server using `npm start`
- Go to [localhost](http://localhost:3000/)
- Check on the top rigth corner of the page and will be a search input
- Compare with the current [docs page](https://docs.clayplatform.com/)

## Intallation process:
https://docusaurus.io/docs/en/search

## Official Algolia site
https://community.algolia.com/docsearch/

Note:
- We need the `Angolia` api key to create the secret and the `indexName`